### PR TITLE
fix(ci): updated Java source and target version to 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <properties>
-        <java.version>1.7</java.version>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <java.version>1.8</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
## Summary
- Updated  and  from  to  in 
- Updated  property from  to 
- Fixes CI build failure: "Source option 7 is no longer supported. Use 8 or later."

## Test plan
- [ ] Verify the CI workflow passes after merging this PR
- [ ] Confirm Maven build completes without Java version errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)