### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,20 +2,21 @@
 
 ## Project Overview
 
-MAIS (Multi Agent Intelligent System) is a distributed, multi-agent security system built with Java 1.7.
+MAIS (Multi Agent Intelligent System) is a distributed, multi-agent security system built with Java 1.8.
 It monitors and enforces process-level security policies across networked machines.
 Agents communicate via Java RMI using a SYN/ACK-inspired protocol, sharing process execution reports and collectively deciding whether to start, kill, or escalate actions on blacklisted or whitelisted processes through consensus-based voting.
 
 ## Technology Stack
 
-- **Language**: Java 1.7 (SDK language level 7)
+- **Language**: Java 1.8 (SDK language level 8)
 - **Build tool**: Apache Maven 3.6+ with `maven-assembly-plugin` for fat JAR packaging
 - **RMI**: Java RMI on port 1099 for inter-agent communication
 - **Process management**: [jProcesses](https://github.com/profesorfalken/jProcesses) 1.6.5
-- **Testing**: JUnit 4.13.1
+- **Testing**: JUnit 4.13.2
 - **Coverage**: JaCoCo with Coveralls integration
 - **CI/CD**: GitHub Actions via a reusable workflow (`rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`)
 - **Code quality**: SonarCloud
+- **Security scanning**: OWASP Dependency-Check Maven plugin (configured with NVD API key)
 
 ## Repository Structure
 
@@ -59,10 +60,10 @@ All commands are run from the repository root.
 
 | Task | Command | Notes |
 |------|---------|-------|
-| Build fat JAR | `mvn clean package` | Output: `target/MAIS-1.0.0-jar-with-dependencies.jar` |
+| Build fat JAR | `mvn clean package` | Output: `target/MAIS-<version>-jar-with-dependencies.jar` |
 | Run tests | `mvn test` | JaCoCo agent is activated automatically |
 | Generate coverage report | `mvn jacoco:report` | Report at `target/site/jacoco/index.html` |
-| Run the agent | `java -jar target/MAIS-1.0.0-jar-with-dependencies.jar` | Requires Java 1.7+ |
+| Run the agent | `java -jar target/MAIS-<version>-jar-with-dependencies.jar` | Requires Java 1.8+ |
 
 Build time is typically under 60 seconds on a standard machine. Tests run in under 30 seconds.
 
@@ -118,7 +119,7 @@ Required permissions: `security-events: write`, `contents: write`.
 
 ## Coding Conventions
 
-- Java 1.7 source and target compatibility — do **not** use Java 8+ language features (lambdas, streams, etc.).
+- Java 1.8 source and target compatibility — do **not** use Java 9+ language features (modules, `var`, etc.). Lambdas and streams are permitted.
 - Group ID: `com.rios0rios0`; keep all production classes under `src/main/java/com/rios0rios0/`.
 - Use the `Console` and `Colorize` utilities for all terminal output rather than `System.out.println`.
 - RMI remote interfaces must extend `java.rmi.Remote`; all remote methods must declare `throws RemoteException`.
@@ -135,8 +136,8 @@ Another RMI registry is running. Stop it or run the agent on a different host. T
 ### Agent cannot find neighbours
 Ensure the hosts are on the same `/24` subnet and that port 1099 is not blocked by a firewall.
 
-### Build fails with "source/target 1.7" errors
-Verify your JDK is 1.7 or later. The Maven compiler source/target is explicitly set to `1.7` in `pom.xml`.
+### Build fails with "source/target 1.8" errors
+Verify your JDK is 1.8 or later. The Maven compiler source/target is explicitly set to `1.8` in `pom.xml`.
 
 ### Coverage report is empty
 Run `mvn test` before `mvn jacoco:report` — the JaCoCo agent must instrument the test run first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `CLAUDE.md` with build commands, architecture overview, and repo conventions for Claude Code sessions
+
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to reflect Java 1.8 (was 1.7), JUnit 4.13.2 (was 4.13.1), current artifact version, and OWASP Dependency-Check plugin
+
 ## [0.1.1] - 2026-04-15
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+MAIS (Multi Agent Intelligent System) — distributed multi-agent security system. Agents discover each other on the local `/24` subnet via Java RMI (port 1099), exchange process reports using a SYN/ACK-inspired protocol, and enforce blacklist/whitelist policies through consensus-based voting.
+
+## Build and test
+
+```bash
+mvn clean package        # compile + fat JAR (target/MAIS-<version>-jar-with-dependencies.jar)
+mvn test                 # run tests (JaCoCo agent activates automatically)
+mvn jacoco:report        # coverage report at target/site/jacoco/index.html (run tests first)
+```
+
+## Architecture
+
+- Three concurrent threads via `ExecutorService`: network scan (5s), report broadcast (15s), policy enforcement (15s).
+- `Agent` is the RMI remote interface; `DefaultAgent` is the abstract base; `SecurityAgent` is the concrete implementation.
+- `Report` is `Serializable` — transmitted over RMI. Must stay serializable.
+- Security policies live in `src/main/resources/blacklist.properties` and `whitelist.properties`.
+
+## Conventions
+
+- Java 1.8 source/target. Do not use Java 9+ features (modules, `var`).
+- All production classes under `src/main/java/com/rios0rios0/`. Group ID: `com.rios0rios0`.
+- Use `Console` and `Colorize` utilities for terminal output, not `System.out.println`.
+- RMI remote interfaces extend `java.rmi.Remote`; all remote methods declare `throws RemoteException`.
+- Tests use JUnit 4 (`@Test`, `@Before`, etc.) under `src/test/java/com/rios0rios0/`.
+- Pin dependency versions in `pom.xml` — no version ranges.
+- Commit conventions: [rios0rios0/guide/wiki](https://github.com/rios0rios0/guide/wiki).
+
+## CI
+
+GitHub Actions workflow (`default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`. Includes OWASP Dependency-Check (requires `NVD_API_KEY` secret) and SonarCloud quality gate.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.