### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Agents communicate via Java RMI using a SYN/ACK-inspired protocol, sharing proce
 - **Process management**: [jProcesses](https://github.com/profesorfalken/jProcesses) 1.6.5
 - **Testing**: JUnit 4.13.2
 - **Coverage**: JaCoCo with Coveralls integration
-- **CI/CD**: GitHub Actions via a reusable workflow (`rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`)
+- **CI/CD**: GitHub Actions via a reusable workflow (`rios0rios0/pipelines/.github/workflows/maven-library.yaml@main`)
 - **Code quality**: SonarCloud
 - **Security scanning**: OWASP Dependency-Check Maven plugin (configured with NVD API key)
 
@@ -97,7 +97,7 @@ apache2=apache2ctl start;apache2ctl stop
 
 ## CI/CD Pipeline
 
-The GitHub Actions workflow (`default.yaml`) delegates to the shared reusable workflow at `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`.
+The GitHub Actions workflow (`default.yaml`) delegates to the shared reusable workflow at `rios0rios0/pipelines/.github/workflows/maven-library.yaml@main`.
 
 It runs on:
 - Pushes to `main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to reference the renamed CI workflow (`maven-library.yaml`, was `java-maven.yaml`)
+
 ## [0.2.0] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,4 +33,4 @@ mvn jacoco:report        # coverage report at target/site/jacoco/index.html (run
 
 ## CI
 
-GitHub Actions workflow (`default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/java-maven.yaml@main`. Includes OWASP Dependency-Check (requires `NVD_API_KEY` secret) and SonarCloud quality gate.
+GitHub Actions workflow (`default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/maven-library.yaml@main`. Includes OWASP Dependency-Check (requires `NVD_API_KEY` secret) and SonarCloud quality gate.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.